### PR TITLE
Release v1.3.2

### DIFF
--- a/DiscordBot/Client/DiscordCommandsService.cs
+++ b/DiscordBot/Client/DiscordCommandsService.cs
@@ -12,7 +12,9 @@ namespace DevSubmarine.DiscordBot.Client
         private readonly InteractionService _interactions;
         private readonly IServiceProvider _services;
         private readonly ILogger _log;
+        private readonly SemaphoreSlim _initializationLock;
         private CancellationTokenSource _cts;
+        private bool _commandsInitialized;
 
         public DiscordCommandsService(DiscordSocketClient client, IServiceProvider services, ILogger<DiscordCommandsService> log, IOptions<DiscordOptions> options)
         {
@@ -20,6 +22,7 @@ namespace DevSubmarine.DiscordBot.Client
             this._services = services;
             this._log = log;
             this._options = options.Value;
+            this._initializationLock = new SemaphoreSlim(1, 1);
             this._interactions = new InteractionService(this._client, new InteractionServiceConfig()
             {
                 DefaultRunMode = RunMode.Sync,
@@ -38,24 +41,37 @@ namespace DevSubmarine.DiscordBot.Client
 
         private async Task OnClientReady()
         {
-            if (this._options.PurgeGlobalCommands)
+            await this._initializationLock.WaitAsync(this._cts?.Token ?? default).ConfigureAwait(false);
+            try
             {
-                this._log.LogDebug("Purging global commands");
-                await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
-            }
+                if (this._commandsInitialized)
+                    return;
 
-            this._log.LogTrace("Loading all command modules");
-            await this._interactions.AddModulesAsync(this.GetType().Assembly, this._services);
+                if (this._options.PurgeGlobalCommands)
+                {
+                    this._log.LogDebug("Purging global commands");
+                    await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
+                }
+                
+                this._log.LogTrace("Loading all command modules");
+                await this._interactions.AddModulesAsync(this.GetType().Assembly, this._services);
 
-            if (this._options.CommandsGuildID != null)
-            {
-                this._log.LogDebug("Registering all commands for guild {GuildID}", this._options.CommandsGuildID.Value);
-                await this._interactions.RegisterCommandsToGuildAsync(this._options.CommandsGuildID.Value).ConfigureAwait(false);
+                if (this._options.CommandsGuildID != null)
+                {
+                    this._log.LogDebug("Registering all commands for guild {GuildID}", this._options.CommandsGuildID.Value);
+                    await this._interactions.RegisterCommandsToGuildAsync(this._options.CommandsGuildID.Value).ConfigureAwait(false);
+                }
+                else
+                {
+                    this._log.LogDebug("Registering all commands globally");
+                    await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
+                }
+
+                this._commandsInitialized = true;
             }
-            else
+            finally
             {
-                this._log.LogDebug("Registering all commands globally");
-                await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
+                this._initializationLock.Release();
             }
         }
 

--- a/DiscordBot/Client/DiscordCommandsService.cs
+++ b/DiscordBot/Client/DiscordCommandsService.cs
@@ -52,7 +52,7 @@ namespace DevSubmarine.DiscordBot.Client
                     this._log.LogDebug("Purging global commands");
                     await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
                 }
-                
+
                 this._log.LogTrace("Loading all command modules");
                 await this._interactions.AddModulesAsync(this.GetType().Assembly, this._services);
 
@@ -143,6 +143,7 @@ namespace DevSubmarine.DiscordBot.Client
             try { this._client.SelectMenuExecuted -= this.OnButtonCommandAsync; } catch { }
             try { this._interactions.Log -= this.OnLog; } catch { }
             try { this._interactions?.Dispose(); } catch { }
+            try { this._initializationLock?.Dispose(); } catch { }
             try { this._cts?.Dispose(); } catch { }
         }
     }

--- a/DiscordBot/Client/DiscordCommandsService.cs
+++ b/DiscordBot/Client/DiscordCommandsService.cs
@@ -47,24 +47,38 @@ namespace DevSubmarine.DiscordBot.Client
                 if (this._commandsInitialized)
                     return;
 
-                if (this._options.PurgeGlobalCommands)
+                if (this._options.RegisterCommandsGlobally)
+                {
+                    if (this._options.CommandsGuildID != null)
+                    {
+                        this._log.LogDebug("Purging commands from guild {GuildID}", this._options.CommandsGuildID.Value);
+                        await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
+                    }
+                }
+                else
                 {
                     this._log.LogDebug("Purging global commands");
                     await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
                 }
 
+
                 this._log.LogTrace("Loading all command modules");
                 await this._interactions.AddModulesAsync(this.GetType().Assembly, this._services);
 
-                if (this._options.CommandsGuildID != null)
+
+                if (this._options.RegisterCommandsGlobally)
+                {
+                    this._log.LogDebug("Registering all commands globally");
+                    await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
+                }
+                else if (this._options.CommandsGuildID != null)
                 {
                     this._log.LogDebug("Registering all commands for guild {GuildID}", this._options.CommandsGuildID.Value);
                     await this._interactions.RegisterCommandsToGuildAsync(this._options.CommandsGuildID.Value).ConfigureAwait(false);
                 }
                 else
                 {
-                    this._log.LogDebug("Registering all commands globally");
-                    await this._interactions.RegisterCommandsGloballyAsync().ConfigureAwait(false);
+                    this._log.LogError("Failed to register commands - either allow global registration or set commands guild ID");
                 }
 
                 this._commandsInitialized = true;

--- a/DiscordBot/Client/DiscordOptions.cs
+++ b/DiscordBot/Client/DiscordOptions.cs
@@ -4,12 +4,11 @@
     {
         /// <summary>Bot token from Discord API portal.</summary>
         public string BotToken { get; set; }
-        /// <summary>ID of guild to register commands to. Should be null, unless testing.</summary>
+        /// <summary>ID of guild to register commands to. Will be ignored if <see cref="RegisterCommandsGlobally"/> is set to true.</summary>
         public ulong? CommandsGuildID { get; set; }
         /// <summary>Compiles commands, which improves their execution speed, but increases memory use.</summary>
         public bool CompileCommands { get; set; }
-        /// <summary>Purges global commands before registering new ones. 
-        /// Only use if registering production bot's commands to guild after they've been already registered globally.</summary>
-        public bool PurgeGlobalCommands { get; set; }
+        /// <summary>Whether commands should be registered globally. Other commands will be purged.</summary>
+        public bool RegisterCommandsGlobally { get;set; } = true;
     }
 }

--- a/DiscordBot/DiscordBot.csproj
+++ b/DiscordBot/DiscordBot.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/DevSubmarine/DiscordBot</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>bot; discord; devsub; devsubmarine</PackageTags>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DiscordBot/Features/AboutCommands.cs
+++ b/DiscordBot/Features/AboutCommands.cs
@@ -18,7 +18,8 @@ namespace DevSubmarine.DiscordBot.Features
 
         [EnabledInDm(true)]
         [SlashCommand("about", "Info about the bot", ignoreGroupNames: true)]
-        public async Task CmdAboutAsync()
+        public async Task CmdAboutAsync(
+            [Summary("Ephemeral", "Whether response should be sent as ephemeral")] bool ephemeral = false)
         {
             IUser user = this._client.CurrentUser;
             IGuildUser guildUser = base.Context.Guild?.GetUser(user.Id);
@@ -54,6 +55,7 @@ namespace DevSubmarine.DiscordBot.Features
             await base.RespondAsync(
                 embed: embed.Build(),
                 components: components.Build(),
+                ephemeral: ephemeral,
                 allowedMentions: AllowedMentions.None,
                 options: base.GetRequestOptions())
                 .ConfigureAwait(false);

--- a/DiscordBot/Features/RandomReactions/IRandomReactionEmoteProvider.cs
+++ b/DiscordBot/Features/RandomReactions/IRandomReactionEmoteProvider.cs
@@ -1,0 +1,9 @@
+namespace DevSubmarine.DiscordBot.RandomReactions
+{
+    public interface IRandomReactionEmoteProvider
+    {
+        IEnumerable<RandomReactionEmote> GetWelcomeEmotes();
+        IEnumerable<RandomReactionEmote> GetFollowupEmotes();
+        IEnumerable<RandomReactionEmote> GetRandomEmotes();
+    }
+}

--- a/DiscordBot/Features/RandomReactions/IWelcomeTriggerProvider.cs
+++ b/DiscordBot/Features/RandomReactions/IWelcomeTriggerProvider.cs
@@ -1,0 +1,13 @@
+namespace DevSubmarine.DiscordBot.RandomReactions
+{
+    public interface IWelcomeTriggerProvider
+    {
+        IEnumerable<WelcomeTrigger> GetWelcomeTriggers();
+    }
+
+    public static class WelcomeTriggerProviderExtensions
+    {
+        public static bool IsAnyMatching(this IWelcomeTriggerProvider provider, string input)
+            => provider.GetWelcomeTriggers().Any(trigger => trigger.IsMatch(input));
+    }
+}

--- a/DiscordBot/Features/RandomReactions/RandomReactionsDependencyInjectionExtensions.cs
+++ b/DiscordBot/Features/RandomReactions/RandomReactionsDependencyInjectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using DevSubmarine.DiscordBot.RandomReactions;
 using DevSubmarine.DiscordBot.RandomReactions.Services;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -13,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (configureOptions != null)
                 services.Configure(configureOptions);
 
+            services.TryAddSingleton<IRandomReactionEmoteProvider, SortedRandomReactionEmoteProvider>();
             services.AddHostedService<RandomReactionsListener>();
 
             return services;

--- a/DiscordBot/Features/RandomReactions/RandomReactionsDependencyInjectionExtensions.cs
+++ b/DiscordBot/Features/RandomReactions/RandomReactionsDependencyInjectionExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.Configure(configureOptions);
 
             services.TryAddSingleton<IRandomReactionEmoteProvider, SortedRandomReactionEmoteProvider>();
+            services.TryAddSingleton<IWelcomeTriggerProvider, WelcomeTriggerProvider>();
             services.AddHostedService<RandomReactionsListener>();
 
             return services;

--- a/DiscordBot/Features/RandomReactions/Services/RandomReactionsListener.cs
+++ b/DiscordBot/Features/RandomReactions/Services/RandomReactionsListener.cs
@@ -28,7 +28,7 @@ namespace DevSubmarine.DiscordBot.RandomReactions.Services
             this._devsubOptions = devsubOptions;
 
             this._client.MessageReceived += this.OnClientMessageReceivedAsync;
-            //this._client.ReactionAdded += this.OnClientReactionAddedAsync;
+            this._client.ReactionAdded += this.OnClientReactionAddedAsync;
         }
 
         private async Task OnClientMessageReceivedAsync(SocketMessage message)
@@ -60,6 +60,8 @@ namespace DevSubmarine.DiscordBot.RandomReactions.Services
             if (messageChannel.Value is not SocketTextChannel channel)
                 return;
             if (channel.Guild.Id != this._devsubOptions.CurrentValue.GuildID)
+                return;
+            if (reaction.UserId == this._client.CurrentUser.Id)
                 return;
             IMessage message = await channel.GetMessageAsync(cachedMessage.Id, this._cts.Token.ToRequestOptions()).ConfigureAwait(false);
             if (message.Author.Id == this._client.CurrentUser.Id)

--- a/DiscordBot/Features/RandomReactions/Services/RandomReactionsListener.cs
+++ b/DiscordBot/Features/RandomReactions/Services/RandomReactionsListener.cs
@@ -10,23 +10,25 @@ namespace DevSubmarine.DiscordBot.RandomReactions.Services
         private readonly DiscordSocketClient _client;
         private readonly IRandomizer _randomizer;
         private readonly IRandomReactionEmoteProvider _emotes;
+        private readonly IWelcomeTriggerProvider _welcomeTriggers;
         private readonly ILogger _log;
         private readonly IOptionsMonitor<RandomReactionsOptions> _options;
         private readonly IOptionsMonitor<DevSubOptions> _devsubOptions;
         private CancellationTokenSource _cts;
 
-        public RandomReactionsListener(DiscordSocketClient client, IRandomizer randomizer, IRandomReactionEmoteProvider emotes,
+        public RandomReactionsListener(DiscordSocketClient client, IRandomizer randomizer, IRandomReactionEmoteProvider emotes, IWelcomeTriggerProvider welcomeTriggers,
             ILogger<RandomReactionsListener> log, IOptionsMonitor<RandomReactionsOptions> options, IOptionsMonitor<DevSubOptions> devsubOptions)
         {
             this._client = client;
             this._randomizer = randomizer;
             this._emotes = emotes;
+            this._welcomeTriggers = welcomeTriggers;
             this._log = log;
             this._options = options;
             this._devsubOptions = devsubOptions;
 
             this._client.MessageReceived += this.OnClientMessageReceivedAsync;
-            this._client.ReactionAdded += this.OnClientReactionAddedAsync;
+            //this._client.ReactionAdded += this.OnClientReactionAddedAsync;
         }
 
         private async Task OnClientMessageReceivedAsync(SocketMessage message)
@@ -80,7 +82,7 @@ namespace DevSubmarine.DiscordBot.RandomReactions.Services
             this._log.LogTrace("Attempting to handle welcome reaction for message {MessageID}", message.Id);
 
             string content = message.Content.TrimStart();
-            if (options.WelcomeTriggers?.Any(trigger => content.StartsWith(trigger, StringComparison.OrdinalIgnoreCase)) != true)
+            if (!this._welcomeTriggers.IsAnyMatching(content))
                 return false;
 
             foreach (RandomReactionEmote emote in this._emotes.GetWelcomeEmotes())

--- a/DiscordBot/Features/RandomReactions/Services/SortedRandomReactionEmoteProvider.cs
+++ b/DiscordBot/Features/RandomReactions/Services/SortedRandomReactionEmoteProvider.cs
@@ -5,8 +5,6 @@ namespace DevSubmarine.DiscordBot.RandomReactions.Services
         private readonly IOptionsMonitor<RandomReactionsOptions> _options;
         private readonly IDisposable _optionsChangeHandle;
 
-        private readonly object _lock = new object();
-
         // we sort emotes by chance to give those with low chance a fair... chance?
         // cache to do it only once per options reload
         private IOrderedEnumerable<RandomReactionEmote> _sortedWelcomeEmotes;
@@ -26,28 +24,28 @@ namespace DevSubmarine.DiscordBot.RandomReactions.Services
         
         public IEnumerable<RandomReactionEmote> GetWelcomeEmotes()
         {
-            lock (this._lock)
-                this._sortedWelcomeEmotes ??= LoadEmotes(this._options.CurrentValue.WelcomeEmotes);
+            this._sortedWelcomeEmotes ??= LoadEmotes(this._options.CurrentValue.WelcomeEmotes);
             return this._sortedWelcomeEmotes;
         }
         
         public IEnumerable<RandomReactionEmote> GetFollowupEmotes()
         {
-            lock (this._lock)
-                this._sortedFollowupEmotes ??= LoadEmotes(this._options.CurrentValue.FollowupEmotes);
+            this._sortedFollowupEmotes ??= LoadEmotes(this._options.CurrentValue.FollowupEmotes);
             return this._sortedFollowupEmotes;
         }
 
         public IEnumerable<RandomReactionEmote> GetRandomEmotes()
         {
-            lock (this._lock)
-                this._sortedRandomEmotes ??= LoadEmotes(this._options.CurrentValue.RandomEmotes);
+            this._sortedRandomEmotes ??= LoadEmotes(this._options.CurrentValue.RandomEmotes);
             return this._sortedRandomEmotes;
         }
 
         private static IOrderedEnumerable<RandomReactionEmote> LoadEmotes(IEnumerable<RandomReactionsOptions.EmoteOptions> config)
-            => config.Select(e => new RandomReactionEmote(e.Emote, e.Chance))
+        {
+            config ??= Enumerable.Empty<RandomReactionsOptions.EmoteOptions>();
+            return config.Select(e => new RandomReactionEmote(e.Emote, e.Chance))
                 .OrderBy(e => e.Chance);
+        }
 
         public void Dispose()
         {

--- a/DiscordBot/Features/RandomReactions/Services/SortedRandomReactionEmoteProvider.cs
+++ b/DiscordBot/Features/RandomReactions/Services/SortedRandomReactionEmoteProvider.cs
@@ -1,0 +1,57 @@
+namespace DevSubmarine.DiscordBot.RandomReactions.Services
+{
+    public class SortedRandomReactionEmoteProvider : IRandomReactionEmoteProvider, IDisposable
+    {
+        private readonly IOptionsMonitor<RandomReactionsOptions> _options;
+        private readonly IDisposable _optionsChangeHandle;
+
+        private readonly object _lock = new object();
+
+        // we sort emotes by chance to give those with low chance a fair... chance?
+        // cache to do it only once per options reload
+        private IOrderedEnumerable<RandomReactionEmote> _sortedWelcomeEmotes;
+        private IOrderedEnumerable<RandomReactionEmote> _sortedFollowupEmotes;
+        private IOrderedEnumerable<RandomReactionEmote> _sortedRandomEmotes;
+        
+        public SortedRandomReactionEmoteProvider(IOptionsMonitor<RandomReactionsOptions> options)
+        {
+            this._options = options;
+            this._optionsChangeHandle = this._options.OnChange(_ =>
+            {
+                this._sortedWelcomeEmotes = null;
+                this._sortedFollowupEmotes = null;
+                this._sortedRandomEmotes = null;
+            });
+        }
+        
+        public IEnumerable<RandomReactionEmote> GetWelcomeEmotes()
+        {
+            lock (this._lock)
+                this._sortedWelcomeEmotes ??= LoadEmotes(this._options.CurrentValue.WelcomeEmotes);
+            return this._sortedWelcomeEmotes;
+        }
+        
+        public IEnumerable<RandomReactionEmote> GetFollowupEmotes()
+        {
+            lock (this._lock)
+                this._sortedFollowupEmotes ??= LoadEmotes(this._options.CurrentValue.FollowupEmotes);
+            return this._sortedFollowupEmotes;
+        }
+
+        public IEnumerable<RandomReactionEmote> GetRandomEmotes()
+        {
+            lock (this._lock)
+                this._sortedRandomEmotes ??= LoadEmotes(this._options.CurrentValue.RandomEmotes);
+            return this._sortedRandomEmotes;
+        }
+
+        private static IOrderedEnumerable<RandomReactionEmote> LoadEmotes(IEnumerable<RandomReactionsOptions.EmoteOptions> config)
+            => config.Select(e => new RandomReactionEmote(e.Emote, e.Chance))
+                .OrderBy(e => e.Chance);
+
+        public void Dispose()
+        {
+            try { this._optionsChangeHandle?.Dispose(); } catch { }
+        }
+    }
+}

--- a/DiscordBot/Features/RandomReactions/Services/WelcomeTriggerProvider.cs
+++ b/DiscordBot/Features/RandomReactions/Services/WelcomeTriggerProvider.cs
@@ -1,0 +1,33 @@
+namespace DevSubmarine.DiscordBot.RandomReactions.Services
+{
+    public class WelcomeTriggerProvider : IWelcomeTriggerProvider, IDisposable
+    {
+        private readonly IOptionsMonitor<RandomReactionsOptions> _options;
+        private readonly IDisposable _optionsChangeHandle;
+
+        private IEnumerable<WelcomeTrigger> _triggers;
+        
+        public WelcomeTriggerProvider(IOptionsMonitor<RandomReactionsOptions> options)
+        {
+            this._options = options;
+            this._optionsChangeHandle = this._options.OnChange(_ =>
+            {
+                this._triggers = null;
+            });
+        }
+
+        public IEnumerable<WelcomeTrigger> GetWelcomeTriggers()
+        {
+            this._triggers ??= LoadTriggers(this._options.CurrentValue.WelcomeTriggers ?? Enumerable.Empty<string>());
+            return this._triggers;
+        }
+
+        private static IEnumerable<WelcomeTrigger> LoadTriggers(IEnumerable<string> config)
+            => config.Select(e => new WelcomeTrigger(e));
+
+        public void Dispose()
+        {
+            try { this._optionsChangeHandle?.Dispose(); } catch { }
+        }
+    }
+}

--- a/DiscordBot/Features/RandomReactions/WelcomeTrigger.cs
+++ b/DiscordBot/Features/RandomReactions/WelcomeTrigger.cs
@@ -1,0 +1,20 @@
+namespace DevSubmarine.DiscordBot.RandomReactions
+{
+    public class WelcomeTrigger
+    {
+        public string RawValue { get; }
+        public Regex ParsedRegex { get; }
+
+        public WelcomeTrigger(string rawValue)
+        {
+            if (string.IsNullOrWhiteSpace(rawValue))
+                throw new ArgumentException("Welcome trigger cannot be an empty string.", nameof(rawValue));
+
+            this.RawValue = rawValue;
+            this.ParsedRegex = new Regex($"^{rawValue}\\b", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+        }
+
+        public bool IsMatch(string input)
+            => this.ParsedRegex.IsMatch(input);
+    }
+}

--- a/DiscordBot/appsettings.Development.json
+++ b/DiscordBot/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "GuildID": 886696135069155348,
+  "RegisterCommandsGlobally": false,
   "CommandsGuildID": 886696135069155348,
 
   "ColourRoles": {

--- a/DiscordBot/appsettings.Development.json
+++ b/DiscordBot/appsettings.Development.json
@@ -38,12 +38,12 @@
     "RandomEmotes": [
       {
         "Emote": "\uD83D\uDE14",
-        "Chance": 1
+        "Chance": 0.1
       }
     ],
     "WelcomeEmotes": [
       {
-        "Emote": "\uD83D\uDE14",
+        "Emote": "\uD83D\uDC4B",
         "Chance": 1
       }
     ],

--- a/DiscordBot/appsettings.Production.json
+++ b/DiscordBot/appsettings.Production.json
@@ -1,6 +1,6 @@
 {
   "GuildID": 441702024715960330,
-  "PurgeGlobalCommands": true,
+  "RegisterCommandsGlobally": true,
   "CommandsGuildID": 441702024715960330,
 
   "ColourRoles": {

--- a/DiscordBot/appsettings.Production.json
+++ b/DiscordBot/appsettings.Production.json
@@ -72,27 +72,27 @@
     "RandomEmotes": [
       {
         "Emote": "<:pepeComfy:966290245668700191>",
-        "Chance": 0.005
+        "Chance": 0.0025
       },
       {
         "Emote": "\uD83D\uDE14",
-        "Chance": 0.001
+        "Chance": 0.0005
       },
       {
         "Emote": "<:FeelsCoffeeMan:557618333990780959>",
-        "Chance": 0.005
+        "Chance": 0.0025
       },
       {
         "Emote": "<:hype:527072821135015936>",
-        "Chance": 0.001
+        "Chance": 0.0005
       },
       {
         "Emote": "<:iAmAgony:880963270318649344>",
-        "Chance": 0.001
+        "Chance": 0.0005
       },
       {
         "Emote": "<:despair:881299750631145492>",
-        "Chance": 0.002
+        "Chance": 0.001
       }
     ],
     "WelcomeEmotes": [

--- a/README.md
+++ b/README.md
@@ -95,10 +95,7 @@ Development Environment Commands shouldn't be registered globally for numerous r
 Better yet, it's recommended to create `appsecrets.Development.json` file - much like in step 3 of [running locally instructions](#running). This file is git-ignored, so your ID will not overwrite settings of others every time you commit changes.
 
 ## Planned Features
-- Whatever we neeed
-
-## Known issues
-- Due to a Discord backend bug, global slash commands do not appear in devsub guild on PC clients. As a *potential* workaround, currently [appsettings.json](DiscordBot/appsettings.json) is set to register only in that guild. This might not work and is less than optimal, but as bot is used currently, this is acceptable and won't hurt.
+- Whatever we need
 
 ## Contributing
 Feel free to open a PR or submit an issue to contribute.


### PR DESCRIPTION
- Attempt to fix seemingly random exception by making bot register to commands only once per startup.
- Slightly toned down random reactions - just random ones, followup and welcome stay the same.
- Cleaned up some ractions code by delegating emotes list loading to its own service.
- Improved welcome reaction handling with some Regex.
- Attempt to switch back to global commands. Maybe it'll work.
- `/about` command now can be requested ephemerally - this is for my own purpose to reduce spam when checking bot version.

This involves some config changes, so yes, replace them.  
No Database change in this update whatsoever.